### PR TITLE
Add Music To Dungeons

### DIFF
--- a/src/client/kotlin/de/fuballer/mcendgame/client/component/datagen/CustomDimensionTypeProvider.kt
+++ b/src/client/kotlin/de/fuballer/mcendgame/client/component/datagen/CustomDimensionTypeProvider.kt
@@ -41,8 +41,28 @@ class CustomDimensionTypeProvider(
         piglinSafe: Boolean = false,
         respawnAnchorWorks: Boolean = false,
         ultrawarm: Boolean = false,
+        musicDefault: String = "minecraft:music.game",
+        musicCreative: String = "minecraft:music.creative",
+        musicMinDelay: Int = 0,
+        musicMaxDelay: Int = 0,
     ) = JsonObject().apply {
         addProperty("ambient_light", ambientLight)
+
+        add("attributes", JsonObject().apply {
+            add("minecraft:audio/background_music", JsonObject().apply {
+                add("creative", JsonObject().apply {
+                    addProperty("max_delay", musicMaxDelay)
+                    addProperty("min_delay", musicMinDelay)
+                    addProperty("sound", musicCreative)
+                })
+                add("default", JsonObject().apply {
+                    addProperty("max_delay", musicMaxDelay)
+                    addProperty("min_delay", musicMinDelay)
+                    addProperty("sound", musicDefault)
+                })
+            })
+        })
+
         addProperty("bed_works", bedWorks)
         addProperty("coordinate_scale", coordinateScale)
         addProperty("effects", effects)

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/dungeon/type/DungeonType.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/dungeon/type/DungeonType.kt
@@ -11,6 +11,9 @@ import de.fuballer.mcendgame.main.component.entity.types.boss.ElfDuelistBossStat
 import de.fuballer.mcendgame.main.util.random.RandomOption
 import de.fuballer.mcendgame.main.util.random.RandomUtil
 import net.minecraft.entity.LivingEntity
+import net.minecraft.registry.RegistryKey
+import net.minecraft.world.biome.Biome
+import net.minecraft.world.biome.BiomeKeys
 import kotlin.random.Random
 
 enum class DungeonType(
@@ -18,6 +21,7 @@ enum class DungeonType(
     private val entityTypes: List<RandomOption<EntityTypeStats>>,
     private val bossEntityTypes: List<RandomOption<EntityTypeStats>>,
     val bossCount: Int,
+    val biome: RegistryKey<Biome>,
     val applyMisc: (List<LivingEntity>) -> Unit = {},
 ) {
     STRONGHOLD(
@@ -39,7 +43,8 @@ enum class DungeonType(
             RandomOption(1, BonecrusherBossStats),
             RandomOption(1, ElfDuelistBossStats),
         ),
-        3,
+        bossCount = 3,
+        biome = BiomeKeys.PLAINS,
     ),
     NETHER(
         listOf(
@@ -59,7 +64,8 @@ enum class DungeonType(
             RandomOption(1, BonecrusherBossStats),
             RandomOption(1, ElfDuelistBossStats),
         ),
-        3,
+        bossCount = 3,
+        biome = BiomeKeys.NETHER_WASTES,
         { enemies -> enemies.forEach { it.addStatusEffect(PotionEffect.FIRE_RESISTANCE.getEffectInstance(false)) } },
     );
 

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/dungeon/world/DungeonWorldService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/dungeon/world/DungeonWorldService.kt
@@ -48,7 +48,7 @@ class DungeonWorldService(
         dungeonExitPos: GlobalPos,
     ): ServerWorld {
         val dungeonWorld = RuntimeConfig.FANTASY
-            .openTemporaryWorld(DungeonWorldSettings.generateIdentifier(), DungeonWorldSettings.getWorldConfig())
+            .openTemporaryWorld(DungeonWorldSettings.generateIdentifier(), DungeonWorldSettings.getWorldConfig(dungeonType.biome))
             .asWorld()
 
         dungeonWorld.setDungeonLevel(dungeonLevel)

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/dungeon/world/DungeonWorldSettings.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/dungeon/world/DungeonWorldSettings.kt
@@ -3,7 +3,9 @@ package de.fuballer.mcendgame.main.component.dungeon.world
 import de.fuballer.mcendgame.main.component.dimension.CustomDimensions
 import de.fuballer.mcendgame.main.configuration.RuntimeConfig
 import de.fuballer.mcendgame.main.util.minecraft.IdentifierUtil
+import net.minecraft.registry.RegistryKey
 import net.minecraft.world.Difficulty
+import net.minecraft.world.biome.Biome
 import net.minecraft.world.rule.GameRules
 import xyz.nucleoid.fantasy.RuntimeWorldConfig
 import xyz.nucleoid.fantasy.util.VoidChunkGenerator
@@ -13,10 +15,12 @@ object DungeonWorldSettings {
     const val EMPTY_WORLD_CHECK_PERIOD = 10 * 60 * 20 // ticks
     const val MAX_EMPTY_TIME = 8 * 60L // seconds
 
-    fun getWorldConfig(): RuntimeWorldConfig = RuntimeWorldConfig()
+    fun getWorldConfig(
+        biome: RegistryKey<Biome>,
+    ): RuntimeWorldConfig = RuntimeWorldConfig()
         .setDimensionType(CustomDimensions.DUNGEON)
         .setDifficulty(Difficulty.HARD)
-        .setGenerator(VoidChunkGenerator(RuntimeConfig.SERVER))
+        .setGenerator(VoidChunkGenerator(RuntimeConfig.SERVER, biome))
         .setTimeOfDay(18000L)
         .setGameRule(GameRules.KEEP_INVENTORY, true)
         .setGameRule(GameRules.DO_MOB_GRIEFING, false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background music configuration support for dimension types.
  * Dungeons now use biome-specific settings (STRONGHOLD: Plains, NETHER: Nether Wastes).
  
* **Improvements**
  * Temporary dungeon worlds now generate with appropriate biome configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->