### PR TITLE
Balance Adjustments

### DIFF
--- a/src/main/java/de/fuballer/mcendgame/main/mixin/attribute/RangedAttributeMixin.java
+++ b/src/main/java/de/fuballer/mcendgame/main/mixin/attribute/RangedAttributeMixin.java
@@ -1,0 +1,30 @@
+package de.fuballer.mcendgame.main.mixin.attribute;
+
+import net.minecraft.world.entity.ai.attributes.RangedAttribute;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RangedAttribute.class)
+public class RangedAttributeMixin {
+    @Mutable
+    @Shadow
+    @Final
+    private double maxValue;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void setArmorMax(
+            String descriptionId,
+            double defaultValue,
+            double minValue,
+            double maxValue,
+            CallbackInfo ci
+    ) {
+        if (!descriptionId.equals("attribute.name.armor")) return;
+        this.maxValue = 2048.0;
+    }
+}

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/AttributesWhilePoisonedService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/AttributesWhilePoisonedService.kt
@@ -12,7 +12,6 @@ import de.maucon.mauconframework.command.CommandHandler
 import de.maucon.mauconframework.di.annotation.Injectable
 import net.minecraft.world.effect.MobEffects
 import net.minecraft.world.entity.LivingEntity
-import kotlin.random.Random
 
 @Injectable
 class AttributesWhilePoisonedService {
@@ -54,12 +53,6 @@ class AttributesWhilePoisonedService {
         if (!cmd.damaged.hasEffect(MobEffects.POISON)) return
 
         val attributes = cmd.damagedAttributes[CustomAttributeTypes.DODGE_WHILE_POISONED] ?: return
-        for (attribute in attributes) {
-            val dodge = attribute.rolls[0].asDoubleRoll().getValue()
-            if (Random.nextDouble() > dodge) continue
-
-            cmd.isDodging = true
-            break
-        }
+        cmd.dodgeChances.addAll(attributes.map { it.rolls[0].asDoubleRoll().getValue() })
     }
 }

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/DodgeIfNotDodgedInLastSecondsService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/DodgeIfNotDodgedInLastSecondsService.kt
@@ -10,7 +10,6 @@ import de.fuballer.mcendgame.main.util.extension.mixin.EntityMixinExtension.upda
 import de.maucon.mauconframework.command.CommandHandler
 import de.maucon.mauconframework.di.annotation.Injectable
 import de.maucon.mauconframework.event.EventSubscriber
-import kotlin.random.Random
 
 @Injectable
 class DodgeIfNotDodgedInLastSecondsService {
@@ -20,14 +19,9 @@ class DodgeIfNotDodgedInLastSecondsService {
 
         for (attribute in attributes) {
             val ticks = attribute.rolls[1].asIntRoll().getValue() * 20
-
             if (cmd.damaged.hasDodged(ticks)) continue
 
-            val dodge = attribute.rolls[0].asDoubleRoll().getValue()
-            if (Random.nextDouble() > dodge) continue
-
-            cmd.isDodging = true
-            return
+            cmd.dodgeChances += attribute.rolls[0].asDoubleRoll().getValue()
         }
     }
 

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/DodgePerMaxHeartBelowTenService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/DodgePerMaxHeartBelowTenService.kt
@@ -5,7 +5,6 @@ import de.fuballer.mcendgame.main.component.custom_attribute.types.CustomAttribu
 import de.fuballer.mcendgame.main.component.damage.dodge.DodgeCalculationCommand
 import de.maucon.mauconframework.command.CommandHandler
 import de.maucon.mauconframework.di.annotation.Injectable
-import kotlin.random.Random
 
 @Injectable
 class DodgePerMaxHeartBelowTenService {
@@ -16,11 +15,7 @@ class DodgePerMaxHeartBelowTenService {
         val missingHearts = (10 - cmd.damaged.maxHealth / 2).toInt()
 
         for (attribute in attributes) {
-            val dodge = attribute.rolls[0].asDoubleRoll().getValue() * missingHearts
-            if (Random.nextDouble() > dodge) continue
-
-            cmd.isDodging = true
-            return
+            cmd.dodgeChances += attribute.rolls[0].asDoubleRoll().getValue() * missingHearts
         }
     }
 }

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/MeleeDamageCanNotBeDodgedService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/MeleeDamageCanNotBeDodgedService.kt
@@ -1,16 +1,17 @@
 package de.fuballer.mcendgame.main.component.custom_attribute.effects.dodge
 
-import de.fuballer.mcendgame.main.component.custom_attribute.CustomAttributesExtensions.asDoubleRoll
 import de.fuballer.mcendgame.main.component.custom_attribute.types.CustomAttributeTypes
 import de.fuballer.mcendgame.main.component.damage.dodge.DodgeCalculationCommand
+import de.fuballer.mcendgame.main.component.tags.CustomTags
 import de.maucon.mauconframework.command.CommandHandler
 import de.maucon.mauconframework.di.annotation.Injectable
 
 @Injectable
-class DodgeService {
+class MeleeDamageCanNotBeDodgedService {
     @CommandHandler
     fun on(cmd: DodgeCalculationCommand) {
-        val attributes = cmd.damagedAttributes[CustomAttributeTypes.DODGE] ?: return
-        cmd.dodgeChances.addAll(attributes.map { it.rolls[0].asDoubleRoll().getValue() })
+        if (!cmd.damagerAttributes.contains(CustomAttributeTypes.MELEE_DAMAGE_CAN_NOT_BE_DODGED)) return
+        if (!cmd.source.`is`(CustomTags.MELEE_ATTACK)) return
+        cmd.canBeDodged = false
     }
 }

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/ProjectileDodgeService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/effects/dodge/ProjectileDodgeService.kt
@@ -5,7 +5,6 @@ import de.fuballer.mcendgame.main.component.custom_attribute.types.CustomAttribu
 import de.fuballer.mcendgame.main.component.damage.dodge.DodgeCalculationCommand
 import de.maucon.mauconframework.command.CommandHandler
 import de.maucon.mauconframework.di.annotation.Injectable
-import kotlin.random.Random
 
 @Injectable
 class ProjectileDodgeService {
@@ -13,13 +12,6 @@ class ProjectileDodgeService {
     fun on(cmd: DodgeCalculationCommand) {
         if (!cmd.isProjectile) return
         val attributes = cmd.damagedAttributes[CustomAttributeTypes.PROJECTILE_DODGE] ?: return
-
-        for (attribute in attributes) {
-            val dodge = attribute.rolls[0].asDoubleRoll().getValue()
-            if (Random.nextDouble() > dodge) continue
-
-            cmd.isDodging = true
-            return
-        }
+        cmd.dodgeChances.addAll(attributes.map { it.rolls[0].asDoubleRoll().getValue() })
     }
 }

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/types/CustomAttributeTypes.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/custom_attribute/types/CustomAttributeTypes.kt
@@ -51,6 +51,7 @@ object CustomAttributeTypes {
         CustomAttributeType("critical_damage_multiplier", AttributeFormats.SIGNED_PERCENT_ROLL, AttributeFormats.PERCENT_BOUNDS, AttributeAffinities.BENEFICIAL)
     val MORE_ATTACK_DAMAGE_PER_ARMOR =
         CustomAttributeType("more_attack_damage_per_armor", AttributeFormats.PERCENT_ROLL, AttributeFormats.PERCENT_BOUNDS, AttributeAffinities.BENEFICIAL, SignBasedKeywords.MORE)
+    val MELEE_DAMAGE_CAN_NOT_BE_DODGED = CustomAttributeType("melee_damage_can_not_be_dodged", AttributeFormats.EMPTY_ROLL, AttributeFormats.EMPTY_BOUNDS, AttributeAffinities.BENEFICIAL)
 
     // BOW
     val BOW_PULL_TICKS = CustomAttributeType("bow_pull_ticks", AttributeFormats.SIGNED_INT_ROLL, AttributeFormats.INT_BOUNDS, AttributeAffinities.DETRIMENTAL)

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/damage/DamageService.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/damage/DamageService.kt
@@ -101,7 +101,7 @@ object DamageService {
         val dodgeCalculationCommand = DodgeCalculationCommand.of(entity, source)
             .let { CommandGateway.apply(it) }
 
-        if (dodgeCalculationCommand.isDodging) {
+        if (dodgeCalculationCommand.isDodging()) {
             val dodgeEvent = LivingEntityDodgedEvent(entity, source.directEntity, source.entity)
             EventGateway.publish(dodgeEvent)
             return true

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/damage/dodge/DodgeCalculationCommand.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/damage/dodge/DodgeCalculationCommand.kt
@@ -4,21 +4,31 @@ import de.fuballer.mcendgame.main.component.custom_attribute.CustomAttributesExt
 import de.fuballer.mcendgame.main.component.custom_attribute.data.CustomAttribute
 import de.fuballer.mcendgame.main.component.custom_attribute.data.CustomAttributeType
 import net.minecraft.world.damagesource.DamageSource
-import net.minecraft.world.damagesource.DamageType
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.projectile.arrow.AbstractArrow
+import kotlin.random.Random
 
 data class DodgeCalculationCommand(
     val damaged: LivingEntity,
     val damagedAttributes: Map<CustomAttributeType, List<CustomAttribute>>,
-    val type: DamageType,
+    val damagerAttributes: Map<CustomAttributeType, List<CustomAttribute>>,
+    val source: DamageSource,
     val isProjectile: Boolean,
-    var isDodging: Boolean = false,
+    val dodgeChances: MutableList<Double> = mutableListOf(),
+    var canBeDodged: Boolean = true,
 ) {
     companion object {
         fun of(
             damaged: LivingEntity,
             source: DamageSource,
-        ) = DodgeCalculationCommand(damaged, damaged.getAllCustomAttributes(), source.type(), source.directEntity is AbstractArrow)
+        ) = DodgeCalculationCommand(
+            damaged,
+            damaged.getAllCustomAttributes(),
+            (source.entity as? LivingEntity)?.getAllCustomAttributes() ?: mapOf(),
+            source,
+            source.directEntity is AbstractArrow
+        )
     }
+
+    fun isDodging() = canBeDodged && Random.nextDouble() > dodgeChances.fold(1.0) { a, b -> a * (1 - b) }
 }

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/damage/dodge/DodgeCalculationCommand.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/damage/dodge/DodgeCalculationCommand.kt
@@ -16,6 +16,7 @@ data class DodgeCalculationCommand(
     val isProjectile: Boolean,
     val dodgeChances: MutableList<Double> = mutableListOf(),
     var canBeDodged: Boolean = true,
+    val randomRoll: Double = Random.nextDouble(),
 ) {
     companion object {
         fun of(
@@ -30,5 +31,5 @@ data class DodgeCalculationCommand(
         )
     }
 
-    fun isDodging() = canBeDodged && Random.nextDouble() > dodgeChances.fold(1.0) { a, b -> a * (1 - b) }
+    fun isDodging() = canBeDodged && randomRoll > dodgeChances.fold(1.0) { a, b -> a * (1 - b) }
 }

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/item/custom/tool/item/Gravebreaker.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/item/custom/tool/item/Gravebreaker.kt
@@ -34,6 +34,7 @@ class Gravebreaker(
     override fun getCustomAttributes() = listOf(
         RollableCustomAttribute(CustomAttributeTypes.MORE_ATTACK_DAMAGE_PER_ARMOR, 0, DoubleBounds(0.03, 0.04)),
         RollableCustomAttribute(CustomAttributeTypes.GAIN_ENEMY_ARMOR_ON_KILL, 0, DoubleBounds(0.08, 0.12), IntBounds(10)),
+        RollableCustomAttribute(CustomAttributeTypes.MELEE_DAMAGE_CAN_NOT_BE_DODGED, 0),
         RollableCustomAttribute(VanillaAttributeTypes.MORE_ATTACK_SPEED, 0, DoubleBounds(-0.25, -0.2)),
     )
 

--- a/src/main/kotlin/de/fuballer/mcendgame/main/component/item/custom/totem/item/TotemOfRecoveryItem.kt
+++ b/src/main/kotlin/de/fuballer/mcendgame/main/component/item/custom/totem/item/TotemOfRecoveryItem.kt
@@ -15,9 +15,9 @@ class TotemOfRecoveryItem(
 
     override fun getCustomAttributes(tier: Int) =
         when (tier) {
-            0 -> listOf(CustomAttribute(CustomAttributeTypes.REGENERATION_WHEN_HIT_BY_ENEMY, 0, listOf(IntRoll(IntBounds(1)), IntRoll(IntBounds(5)))))
-            1 -> listOf(CustomAttribute(CustomAttributeTypes.REGENERATION_WHEN_HIT_BY_ENEMY, 0, listOf(IntRoll(IntBounds(2)), IntRoll(IntBounds(5)))))
-            2 -> listOf(CustomAttribute(CustomAttributeTypes.REGENERATION_WHEN_HIT_BY_ENEMY, 0, listOf(IntRoll(IntBounds(3)), IntRoll(IntBounds(4)))))
+            0 -> listOf(CustomAttribute(CustomAttributeTypes.REGENERATION_WHEN_HIT_BY_ENEMY, 0, listOf(IntRoll(IntBounds(1)), IntRoll(IntBounds(4)))))
+            1 -> listOf(CustomAttribute(CustomAttributeTypes.REGENERATION_WHEN_HIT_BY_ENEMY, 0, listOf(IntRoll(IntBounds(1)), IntRoll(IntBounds(7)))))
+            2 -> listOf(CustomAttribute(CustomAttributeTypes.REGENERATION_WHEN_HIT_BY_ENEMY, 0, listOf(IntRoll(IntBounds(2)), IntRoll(IntBounds(5)))))
             else -> listOf()
         }
 }

--- a/src/main/resources/assets/mcendgame/lang/en_us.json
+++ b/src/main/resources/assets/mcendgame/lang/en_us.json
@@ -224,6 +224,7 @@
   "attribute.mcendgame.more_damage": " %s%% %s Damage",
   "attribute.mcendgame.more_damage_per_missing_heart": " %s%% %s Damage per missing Heart",
   "attribute.mcendgame.more_attack_damage_per_armor": " %s%% %s Attack Damage per Armor",
+  "attribute.mcendgame.melee_damage_can_not_be_dodged": " Your Melee Damage can not be Dodged",
   "attribute.mcendgame.gain_enemy_armor_on_kill": " Gain %s%% of Enemy Armor for %ss on Kill",
   "attribute.mcendgame.increased_elemental_damage": "%s%% %s Elemental Damage",
   "attribute.mcendgame.increased_projectile_damage": "%s%% %s Projectile Damage",

--- a/src/main/resources/mcendgame.mixins.json
+++ b/src/main/resources/mcendgame.mixins.json
@@ -7,6 +7,7 @@
     "access.PlayerAccessMixin",
     "additional_arrows.AbstractSkeletonAdditionalArrowsMixin",
     "additional_arrows.ProjectileWeaponItemAdditionalArrowsMixin",
+    "attribute.RangedAttributeMixin",
     "conversion.SkeletonConversionMixin",
     "conversion.ZombieConversionMixin",
     "corruption.AnvilMenuCorruptionUnmodifiableMixin",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Melee Damage Can Not Be Dodged" attribute and related item rollout
  * Gravebreaker now grants the new anti-dodge attribute

* **Balance Changes**
  * Dodge mechanics reworked to aggregate dodge chances before resolution
  * Adjusted Totem of Recovery regeneration values by tier
  * Increased armor attribute maximum to allow much higher values

* **Localization**
  * Added English text for the new attribute
<!-- end of auto-generated comment: release notes by coderabbit.ai -->